### PR TITLE
Secure Password Change for Clients

### DIFF
--- a/app/account-settings/page.tsx
+++ b/app/account-settings/page.tsx
@@ -14,6 +14,8 @@ export default function AccountSettings() {
   const [showPasswordForm, setShowPasswordForm] = useState(false);
   const [isPasswordPromptComplete, setIsPasswordPromptComplete] = useState(false);
   const [passwordPromptValue, setPasswordPromptValue] = useState("");
+  const [reauthEmail, setReauthEmail] = useState("");
+  const [isReauthenticating, setIsReauthenticating] = useState(false);
   const [passwordMessage, setPasswordMessage] = useState({ type: "", text: "" });
   const [passwordForm, setPasswordForm] = useState({
     currentPassword: "",
@@ -71,17 +73,48 @@ export default function AccountSettings() {
     setPasswordForm((prev) => ({ ...prev, [field]: value }));
   };
 
-  const handlePasswordPromptContinue = (event?: React.FormEvent) => {
+  const handlePasswordPromptContinue = async (event?: React.FormEvent) => {
     event?.preventDefault();
 
-    if (!passwordPromptValue) {
-      setPasswordMessage({ type: "error", text: "Please enter your current password to continue." });
+    if (!reauthEmail || !passwordPromptValue) {
+      setPasswordMessage({ type: "error", text: "Please enter your email and current password to continue." });
       return;
     }
 
+    setIsReauthenticating(true);
     setPasswordMessage({ type: "", text: "" });
-    setPasswordForm((prev) => ({ ...prev, currentPassword: passwordPromptValue }));
-    setIsPasswordPromptComplete(true);
+
+    try {
+      const response = await fetch("/api/auth/reauth", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: reauthEmail,
+          password: passwordPromptValue,
+        }),
+      });
+
+      const payload = await response.json();
+
+      if (!response.ok) {
+        setPasswordMessage({
+          type: "error",
+          text: payload?.error || "Invalid email or password.",
+        });
+        return;
+      }
+
+      setPasswordMessage({ type: "", text: "" });
+      setPasswordForm((prev) => ({ ...prev, currentPassword: passwordPromptValue }));
+      setIsPasswordPromptComplete(true);
+    } catch (error) {
+      setPasswordMessage({
+        type: "error",
+        text: "Unable to verify credentials. Please try again.",
+      });
+    } finally {
+      setIsReauthenticating(false);
+    }
   };
 
   const handlePasswordChange = async (event: React.FormEvent) => {
@@ -118,8 +151,9 @@ export default function AccountSettings() {
         return;
       }
 
-      setPasswordMessage({ type: "success", text: "Password updated successfully." });
+      setPasswordMessage({ type: "success", text: "Password reset was successful." });
       setPasswordPromptValue("");
+      setReauthEmail("");
       setPasswordForm({ currentPassword: "", newPassword: "", confirmPassword: "" });
       setIsPasswordPromptComplete(false);
       setShowPasswordForm(false);
@@ -238,113 +272,76 @@ export default function AccountSettings() {
         </div>
 
         {/* Change Password */}
-        <div className="bg-white p-6 rounded-xl border border-gray-200 shadow-sm">
-          <h2 className="font-display text-3xl text-gray-900 mb-2">Change Password</h2>
+        {userType === "client" && (
+          <div className="bg-white p-6 rounded-xl border border-gray-200 shadow-sm">
+            <h2 className="font-display text-3xl text-gray-900 mb-2">Change Password</h2>
 
-          {passwordMessage.text && (
-            <div
-              className={`mb-4 rounded-lg p-3 text-sm ${
-                passwordMessage.type === "success"
-                  ? "bg-emerald-50 text-emerald-700"
-                  : "bg-red-50 text-red-700"
-              }`}
-            >
-              {passwordMessage.text}
-            </div>
-          )}
+            {passwordMessage.text && (
+              <div
+                className={`mb-4 rounded-lg p-3 text-sm ${
+                  passwordMessage.type === "success"
+                    ? "bg-emerald-50 text-emerald-700"
+                    : "bg-red-50 text-red-700"
+                }`}
+              >
+                {passwordMessage.text}
+              </div>
+            )}
 
-          {!showPasswordForm ? (
-            <button
-              type="button"
-              onClick={() => {
-                setPasswordMessage({ type: "", text: "" });
-                setPasswordPromptValue("");
-                setPasswordForm({ currentPassword: "", newPassword: "", confirmPassword: "" });
-                setIsPasswordPromptComplete(false);
-                setShowPasswordForm(true);
-              }}
-              className="rounded-xl bg-red-600 px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-white transition hover:bg-red-700"
-            >
-              Change Password
-            </button>
-          ) : (
-            <>
-              {!isPasswordPromptComplete ? (
-                <form onSubmit={handlePasswordPromptContinue} className="grid gap-4 md:grid-cols-2" autoComplete="off">
-                  <div className="md:col-span-2">
-                    <label className="mb-2 block text-sm font-medium text-gray-700">Confirm Your Current Password</label>
-                    <input
-                      type="password"
-                      value={passwordPromptValue}
-                      onChange={(event) => setPasswordPromptValue(event.target.value)}
-                      className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
-                      autoComplete="off"
-                      required
-                    />
-                  </div>
-                  <div className="md:col-span-2 flex gap-3">
-                    <button
-                      type="submit"
-                      className="rounded-xl bg-primary px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-white transition hover:bg-primary/90"
-                    >
-                      Continue
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setPasswordPromptValue("");
-                        setPasswordForm({ currentPassword: "", newPassword: "", confirmPassword: "" });
-                        setPasswordMessage({ type: "", text: "" });
-                        setIsPasswordPromptComplete(false);
-                        setShowPasswordForm(false);
-                      }}
-                      className="rounded-xl border border-gray-300 px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-gray-700 transition hover:bg-gray-50"
-                    >
-                      Cancel
-                    </button>
-                  </div>
-                </form>
-              ) : (
-                <>
-                  <p className="text-sm text-gray-600 mb-4">{PASSWORD_POLICY_MESSAGE}</p>
-
-                  <form onSubmit={handlePasswordChange} className="grid gap-4 md:grid-cols-2" autoComplete="off">
+            {!showPasswordForm ? (
+              <button
+                type="button"
+                onClick={() => {
+                  setPasswordMessage({ type: "", text: "" });
+                  setPasswordPromptValue("");
+                  setReauthEmail("");
+                  setPasswordForm({ currentPassword: "", newPassword: "", confirmPassword: "" });
+                  setIsPasswordPromptComplete(false);
+                  setShowPasswordForm(true);
+                }}
+                className="rounded-xl bg-red-600 px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-white transition hover:bg-red-700"
+              >
+                Change Password
+              </button>
+            ) : (
+              <>
+                {!isPasswordPromptComplete ? (
+                  <form onSubmit={handlePasswordPromptContinue} className="grid gap-4 md:grid-cols-2" autoComplete="off">
                     <div>
-                      <label className="mb-2 block text-sm font-medium text-gray-700">New Password</label>
+                      <label className="mb-2 block text-sm font-medium text-gray-700">Confirm Your Email</label>
                       <input
-                        type="password"
-                        value={passwordForm.newPassword}
-                        onChange={(event) => handlePasswordFieldChange("newPassword", event.target.value)}
+                        type="email"
+                        value={reauthEmail}
+                        onChange={(event) => setReauthEmail(event.target.value)}
                         className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
-                        autoComplete="new-password"
+                        autoComplete="email"
                         required
                       />
                     </div>
-
                     <div>
-                      <label className="mb-2 block text-sm font-medium text-gray-700">Confirm New Password</label>
+                      <label className="mb-2 block text-sm font-medium text-gray-700">Confirm Your Current Password</label>
                       <input
                         type="password"
-                        value={passwordForm.confirmPassword}
-                        onChange={(event) => handlePasswordFieldChange("confirmPassword", event.target.value)}
+                        value={passwordPromptValue}
+                        onChange={(event) => setPasswordPromptValue(event.target.value)}
                         className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
-                        autoComplete="new-password"
+                        autoComplete="current-password"
                         required
                       />
                     </div>
-
                     <div className="md:col-span-2 flex gap-3">
                       <button
                         type="submit"
-                        disabled={changingPassword}
+                        disabled={isReauthenticating}
                         className="rounded-xl bg-primary px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-white transition hover:bg-primary/90 disabled:opacity-50"
                       >
-                        {changingPassword ? "Updating..." : "Update Password"}
+                        {isReauthenticating ? "Verifying..." : "Continue"}
                       </button>
                       <button
                         type="button"
                         onClick={() => {
                           setPasswordPromptValue("");
+                          setReauthEmail("");
                           setPasswordForm({ currentPassword: "", newPassword: "", confirmPassword: "" });
                           setPasswordMessage({ type: "", text: "" });
                           setIsPasswordPromptComplete(false);
@@ -356,11 +353,65 @@ export default function AccountSettings() {
                       </button>
                     </div>
                   </form>
-                </>
-              )}
-            </>
-          )}
-        </div>
+                ) : (
+                  <>
+                    <p className="text-sm text-gray-600 mb-4">{PASSWORD_POLICY_MESSAGE}</p>
+
+                    <form onSubmit={handlePasswordChange} className="grid gap-4 md:grid-cols-2" autoComplete="off">
+                      <div>
+                        <label className="mb-2 block text-sm font-medium text-gray-700">New Password</label>
+                        <input
+                          type="password"
+                          value={passwordForm.newPassword}
+                          onChange={(event) => handlePasswordFieldChange("newPassword", event.target.value)}
+                          className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                          autoComplete="new-password"
+                          required
+                        />
+                      </div>
+
+                      <div>
+                        <label className="mb-2 block text-sm font-medium text-gray-700">Confirm New Password</label>
+                        <input
+                          type="password"
+                          value={passwordForm.confirmPassword}
+                          onChange={(event) => handlePasswordFieldChange("confirmPassword", event.target.value)}
+                          className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                          autoComplete="new-password"
+                          required
+                        />
+                      </div>
+
+                      <div className="md:col-span-2 flex gap-3">
+                        <button
+                          type="submit"
+                          disabled={changingPassword}
+                          className="rounded-xl bg-primary px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-white transition hover:bg-primary/90 disabled:opacity-50"
+                        >
+                          {changingPassword ? "Updating..." : "Update Password"}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setPasswordPromptValue("");
+                            setReauthEmail("");
+                            setPasswordForm({ currentPassword: "", newPassword: "", confirmPassword: "" });
+                            setPasswordMessage({ type: "", text: "" });
+                            setIsPasswordPromptComplete(false);
+                            setShowPasswordForm(false);
+                          }}
+                          className="rounded-xl border border-gray-300 px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-gray-700 transition hover:bg-gray-50"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </form>
+                  </>
+                )}
+              </>
+            )}
+          </div>
+        )}
 
         {userType === "client" && (
           <div className="bg-white p-6 rounded-xl border border-gray-200 shadow-sm mt-8">

--- a/app/api/auth/change-password/route.ts
+++ b/app/api/auth/change-password/route.ts
@@ -3,6 +3,12 @@ import { auth } from "@/app/api/auth/[...nextauth]/route";
 import { getClientById, updateClientPasswordById, getUserById, updateAdminPasswordById } from "@/lib/db";
 import { validatePasswordPolicy } from "@/lib/password-policy";
 import { hashPassword, verifyPassword } from "@/lib/password-utils";
+import { Resend } from "resend";
+import { persistApiError } from "@/lib/error-logger";
+
+const resendApiKey = process.env.RESEND_API_KEY;
+const resend = resendApiKey ? new Resend(resendApiKey) : null;
+const contactFromEmail = process.env.CONTACT_FROM_EMAIL;
 
 type AttemptState = {
   count: number;
@@ -136,6 +142,39 @@ export async function POST(req: NextRequest) {
 
     if (!updated) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    // Send security notification email via Resend
+    if (resend && contactFromEmail && session?.user?.email) {
+      try {
+        const origin = req.nextUrl.origin;
+        const settingsUrl = `${origin}/account-settings`;
+        
+        await resend.emails.send({
+          from: contactFromEmail,
+          to: session.user.email,
+          subject: "Security Alert: Password Changed",
+          html: `
+            <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #e2e8f0; rounded: 12px;">
+              <h2 style="color: #1e293b;">Security Alert</h2>
+              <p>Your password was recently changed. If you did not perform this action, please visit your account settings to reset it again immediately.</p>
+              <div style="margin: 30px 0;">
+                <a href="${settingsUrl}" style="background-color: #2563eb; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: 600;">Account Settings</a>
+              </div>
+              <p style="color: #64748b; font-size: 14px;">This is an automated security notification.</p>
+            </div>
+          `,
+        });
+      } catch (emailError) {
+        console.error("Failed to send security email:", emailError);
+        await persistApiError({
+          route: "/api/auth/change-password",
+          method: "POST",
+          statusCode: 500,
+          error: emailError instanceof Error ? emailError : new Error("Failed to send security email"),
+        });
+        // We don't fail the password change if the email fails, but we logged it.
+      }
     }
 
     clearAttempts(rawUserId as string);

--- a/app/api/auth/reauth/route.ts
+++ b/app/api/auth/reauth/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/app/api/auth/[...nextauth]/route";
+import { getClientByEmail } from "@/lib/db";
+import { verifyPassword } from "@/lib/password-utils";
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await auth();
+    const rawUserId = session?.user?.id;
+
+    if (!rawUserId || !rawUserId.startsWith("client:")) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { email, password } = await req.json();
+
+    if (!email || !password) {
+      return NextResponse.json({ error: "Missing email or password" }, { status: 400 });
+    }
+
+    // Verify the email matches the session email for security
+    if (session.user?.email !== email) {
+      return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
+    }
+
+    const client = await getClientByEmail(email);
+    if (!client || !client.password_hash) {
+      return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
+    }
+
+    const { valid } = await verifyPassword(password, client.password_hash);
+    if (!valid) {
+      return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
+    }
+
+    return NextResponse.json({ message: "Re-authenticated successfully" });
+  } catch (error: unknown) {
+    console.error("Re-auth error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Description
This PR implements a more secure password change flow for client accounts as specified in issue #31.

### Changes:
- **Restriction**: The 'Change Password' card is now only visible to users with the 'client' role on the \/account-settings\ page.
- **Re-authentication**: Before changing their password, clients must now 're-login' by providing both their email and current password. This is handled by a new \/api/auth/reauth\ endpoint.
- **Security Notification**: After a successful password change, a security alert email is sent to the user via the Resend API, notifying them of the change and providing a link back to settings.
- **UI Update**: Updated the success message to explicitly state 'Password reset was successful.'

Fixes #31