### PR TITLE
Add Account Info section with re-auth and security alert [Issue #35]

### DIFF
--- a/app/account-settings/page.tsx
+++ b/app/account-settings/page.tsx
@@ -5,16 +5,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import Header from "@/components/Header";
 import { BILLING_FIELD_LIMITS, BillingField, ACCOUNT_INFO_FIELD_LIMITS, AccountInfoField } from "@/lib/field-limits";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Pencil } from "lucide-react";
 
 function AccountSettingsContent() {
@@ -300,62 +291,77 @@ function AccountSettingsContent() {
               </div>
             )}
 
-            <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-              <DialogContent className="sm:max-w-[425px]">
-                <form onSubmit={handleDialogSave}>
-                  <DialogHeader>
-                    <DialogTitle>Edit {editingField === "company_name" ? "Company Name" : editingField === "phone" ? "Phone Number" : "Email Address"}</DialogTitle>
-                  </DialogHeader>
-                  <div className="grid gap-4 py-4">
-                    <div className="grid gap-2">
-                      <div className="flex justify-between items-center">
-                        <Label htmlFor="tempValue">
-                          {editingField === "company_name" ? "Company Name" : editingField === "phone" ? "Phone Number" : "Email Address"}
-                        </Label>
-                        {editingField && tempValue.length >= ACCOUNT_INFO_FIELD_LIMITS[editingField] && (
-                          <span className="text-[10px] font-bold uppercase text-red-600 animate-pulse">Max length reached</span>
-                        )}
+            {isDialogOpen && (
+              <div
+                className="fixed inset-0 bg-gray-500/40 backdrop-blur-sm flex items-center justify-center p-4 z-50"
+                onClick={() => setIsDialogOpen(false)}
+              >
+                <div className="bg-white rounded-lg max-w-md w-full" onClick={(e) => e.stopPropagation()}>
+                  <form onSubmit={handleDialogSave}>
+                    <div className="px-6 py-4 border-b">
+                      <h3 className="text-lg font-semibold">
+                        Edit {editingField === "company_name" ? "Company Name" : editingField === "phone" ? "Phone Number" : "Email Address"}
+                      </h3>
+                    </div>
+                    
+                    <div className="px-6 py-4 space-y-4">
+                      <div>
+                        <div className="flex justify-between items-center mb-1">
+                          <label className="block text-sm font-medium text-gray-700">
+                            {editingField === "company_name" ? "Company Name" : editingField === "phone" ? "Phone Number" : "Email Address"}
+                          </label>
+                          {editingField && tempValue.length >= ACCOUNT_INFO_FIELD_LIMITS[editingField] && (
+                            <span className="text-[10px] font-bold uppercase text-red-600 animate-pulse">Max length reached</span>
+                          )}
+                        </div>
+                        <input
+                          type={editingField === "email" ? "email" : editingField === "phone" ? "tel" : "text"}
+                          value={tempValue}
+                          onChange={(e) => {
+                            const val = e.target.value;
+                            if (editingField) {
+                              const limit = ACCOUNT_INFO_FIELD_LIMITS[editingField];
+                              if (limit && val.length > limit) return;
+                            }
+                            setTempValue(val);
+                          }}
+                          className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                          required={editingField !== "phone"}
+                          autoComplete={editingField === "company_name" ? "organization" : editingField === "phone" ? "tel" : "email"}
+                        />
                       </div>
-                      <Input
-                        id="tempValue"
-                        type={editingField === "email" ? "email" : editingField === "phone" ? "tel" : "text"}
-                        value={tempValue}
-                        onChange={(e) => {
-                          const val = e.target.value;
-                          if (editingField) {
-                            const limit = ACCOUNT_INFO_FIELD_LIMITS[editingField];
-                            if (limit && val.length > limit) return;
-                          }
-                          setTempValue(val);
-                        }}
-                        className="col-span-3"
-                        required={editingField !== "phone"}
-                      />
+                      
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Current Password</label>
+                        <input
+                          type="password"
+                          value={tempPassword}
+                          onChange={(e) => setTempPassword(e.target.value)}
+                          placeholder="Confirm with your password"
+                          className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                          required
+                          autoComplete="current-password"
+                        />
+                      </div>
                     </div>
-                    <div className="grid gap-2">
-                      <Label htmlFor="tempPassword">Current Password</Label>
-                      <Input
-                        id="tempPassword"
-                        type="password"
-                        value={tempPassword}
-                        onChange={(e) => setTempPassword(e.target.value)}
-                        placeholder="Confirm with your password"
-                        className="col-span-3"
-                        required
-                      />
+
+                    <div className="px-6 py-4 border-t flex justify-end gap-3">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => setIsDialogOpen(false)}
+                        disabled={savingAccount}
+                      >
+                        Cancel
+                      </Button>
+                      <Button type="submit" disabled={savingAccount}>
+                        {savingAccount ? "Saving..." : "Save Changes"}
+                      </Button>
                     </div>
-                  </div>
-                  <DialogFooter>
-                    <Button type="button" variant="outline" onClick={() => setIsDialogOpen(false)} disabled={savingAccount}>
-                      Cancel
-                    </Button>
-                    <Button type="submit" disabled={savingAccount}>
-                      {savingAccount ? "Saving..." : "Save Changes"}
-                    </Button>
-                  </DialogFooter>
-                </form>
-              </DialogContent>
-            </Dialog>
+                  </form>
+                </div>
+              </div>
+            )}
           </div>
         )}
 
@@ -412,6 +418,7 @@ function AccountSettingsContent() {
                     onChange={(event) => handleBillingChange("billing_address_line1", event.target.value)}
                     className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
                     required
+                    autoComplete="address-line1"
                   />
                 </div>
                 <div className="md:col-span-2">
@@ -426,6 +433,7 @@ function AccountSettingsContent() {
                     value={billingForm.billing_address_line2}
                     onChange={(event) => handleBillingChange("billing_address_line2", event.target.value)}
                     className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                    autoComplete="address-line2"
                   />
                 </div>
                 <div>
@@ -441,6 +449,7 @@ function AccountSettingsContent() {
                     onChange={(event) => handleBillingChange("billing_city", event.target.value)}
                     className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
                     required
+                    autoComplete="address-level2"
                   />
                 </div>
                 <div>
@@ -450,6 +459,7 @@ function AccountSettingsContent() {
                     onChange={(event) => handleBillingChange("billing_state", event.target.value)}
                     className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
                     required
+                    autoComplete="address-level1"
                   >
                     <option value="">Select State</option>
                     {US_STATES.map((abbr) => (
@@ -470,6 +480,7 @@ function AccountSettingsContent() {
                     onChange={(event) => handleBillingChange("billing_postal_code", event.target.value)}
                     className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
                     required
+                    autoComplete="postal-code"
                   />
                 </div>
                 {/* Country field removed: US only */}

--- a/app/account-settings/page.tsx
+++ b/app/account-settings/page.tsx
@@ -8,6 +8,15 @@ import { BILLING_FIELD_LIMITS, BillingField, ACCOUNT_INFO_FIELD_LIMITS, AccountI
 import { Button } from "@/components/ui/button";
 import { Pencil } from "lucide-react";
 
+function formatPhoneNumber(value: string): string {
+  const digits = value.replace(/\D/g, "").slice(0, 10);
+
+  if (digits.length <= 3) return digits;
+  if (digits.length <= 6) return `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
+
+  return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+}
+
 function AccountSettingsContent() {
   const { data: session, status, update } = useSession();
   const router = useRouter();
@@ -318,8 +327,10 @@ function AccountSettingsContent() {
                           type={editingField === "email" ? "email" : editingField === "phone" ? "tel" : "text"}
                           value={tempValue}
                           onChange={(e) => {
-                            const val = e.target.value;
-                            if (editingField) {
+                            let val = e.target.value;
+                            if (editingField === "phone") {
+                              val = formatPhoneNumber(val);
+                            } else if (editingField) {
                               const limit = ACCOUNT_INFO_FIELD_LIMITS[editingField];
                               if (limit && val.length > limit) return;
                             }
@@ -328,6 +339,8 @@ function AccountSettingsContent() {
                           className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
                           required={editingField !== "phone"}
                           autoComplete={editingField === "company_name" ? "organization" : editingField === "phone" ? "tel" : "email"}
+                          inputMode={editingField === "phone" ? "numeric" : "text"}
+                          placeholder={editingField === "phone" ? "(555) 123-4567" : ""}
                         />
                       </div>
                       

--- a/app/account-settings/page.tsx
+++ b/app/account-settings/page.tsx
@@ -5,6 +5,17 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import Header from "@/components/Header";
 import { BILLING_FIELD_LIMITS, BillingField, ACCOUNT_INFO_FIELD_LIMITS, AccountInfoField } from "@/lib/field-limits";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Pencil } from "lucide-react";
 
 function AccountSettingsContent() {
   const { data: session, status, update } = useSession();
@@ -30,6 +41,11 @@ function AccountSettingsContent() {
     currentPassword: "",
   });
   const [originalEmail, setOriginalEmail] = useState("");
+
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [editingField, setEditingField] = useState<AccountInfoField | null>(null);
+  const [tempValue, setTempValue] = useState("");
+  const [tempPassword, setTempPassword] = useState("");
 
   const [attemptedExceed, setAttemptedExceed] = useState<Partial<Record<BillingField | AccountInfoField, boolean>>>({});
 
@@ -97,53 +113,57 @@ function AccountSettingsContent() {
     }
   };
 
-  const handleAccountChange = (field: AccountInfoField | 'currentPassword', value: string) => {
-    if (field !== 'currentPassword') {
-      const limit = ACCOUNT_INFO_FIELD_LIMITS[field as AccountInfoField];
-      if (limit && value.length > limit) {
-        if (!attemptedExceed[field as AccountInfoField]) {
-          setAttemptedExceed((prev) => ({ ...prev, [field]: true }));
-        }
-        return;
-      }
-      
-      const isAtLimit = limit ? value.length >= limit : false;
-      if (!isAtLimit) {
-        setAttemptedExceed((prev) => ({ ...prev, [field as AccountInfoField]: false }));
-      }
-    }
-
-    setAccountForm((prev) => ({ ...prev, [field]: value }));
+  const handleOpenEditDialog = (field: AccountInfoField) => {
+    setEditingField(field);
+    setTempValue(accountForm[field] || "");
+    setTempPassword("");
+    setIsDialogOpen(true);
+    setAccountMessage({ type: "", text: "" });
   };
 
-  const handleAccountSave = async (event: React.FormEvent) => {
+  const handleDialogSave = async (event: React.FormEvent) => {
     event.preventDefault();
+    if (!editingField) return;
+
     setSavingAccount(true);
     setAccountMessage({ type: "", text: "" });
+
+    // Build the payload with the updated field and current values for others
+    const payload = {
+      ...accountForm,
+      [editingField]: tempValue,
+      currentPassword: tempPassword,
+    };
 
     try {
       const response = await fetch("/api/clients/me", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(accountForm),
+        body: JSON.stringify(payload),
       });
 
-      const payload = await response.json();
+      const data = await response.json();
       if (!response.ok) {
-        setAccountMessage({ type: "error", text: payload?.error || "Unable to save account info." });
+        setAccountMessage({ type: "error", text: data?.error || "Unable to save account info." });
         return;
       }
 
       setAccountMessage({ type: "success", text: "Account information saved successfully." });
       
+      // Update local state
+      setAccountForm(prev => ({
+        ...prev,
+        [editingField]: tempValue,
+        currentPassword: "",
+      }));
+
       // If email changed, update the session
-      if (accountForm.email !== originalEmail) {
-        await update({ email: accountForm.email });
-        setOriginalEmail(accountForm.email);
+      if (editingField === "email" && tempValue !== originalEmail) {
+        await update({ email: tempValue });
+        setOriginalEmail(tempValue);
       }
       
-      // Clear password field
-      setAccountForm(prev => ({ ...prev, currentPassword: "" }));
+      setIsDialogOpen(false);
     } catch {
       setAccountMessage({ type: "error", text: "Unable to save account info." });
     } finally {
@@ -257,82 +277,85 @@ function AccountSettingsContent() {
             {accountLoading ? (
               <p className="text-gray-600">Loading account information...</p>
             ) : (
-              <form onSubmit={handleAccountSave} className="grid gap-4">
-                <div>
-                  <div className="flex justify-between items-end mb-2">
-                    <label className="block text-sm font-medium text-gray-700">Company Name *</label>
-                    {attemptedExceed.company_name && (
-                      <span className="text-[10px] font-bold uppercase text-red-600 animate-pulse">Maximum length reached</span>
-                    )}
+              <div className="space-y-6">
+                {[
+                  { id: "company_name", label: "Company Name", value: accountForm.company_name },
+                  { id: "phone", label: "Phone Number", value: accountForm.phone || "Not set" },
+                  { id: "email", label: "Email Address", value: accountForm.email },
+                ].map((field) => (
+                  <div key={field.id} className="flex items-center justify-between border-b border-gray-100 pb-4 last:border-0 last:pb-0">
+                    <div>
+                      <p className="text-sm font-medium text-gray-500">{field.label}</p>
+                      <p className="text-lg text-gray-900">{field.value}</p>
+                    </div>
+                    <button
+                      onClick={() => handleOpenEditDialog(field.id as AccountInfoField)}
+                      className="p-2 text-gray-400 hover:text-blue-600 transition-colors"
+                      title={`Edit ${field.label}`}
+                    >
+                      <Pencil className="w-5 h-5" />
+                    </button>
                   </div>
-                  <input
-                    type="text"
-                    value={accountForm.company_name}
-                    onChange={(e) => handleAccountChange("company_name", e.target.value)}
-                    className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
-                    required
-                  />
-                </div>
-                <div>
-                  <div className="flex justify-between items-end mb-2">
-                    <label className="block text-sm font-medium text-gray-700">Phone Number</label>
-                    {attemptedExceed.phone && (
-                      <span className="text-[10px] font-bold uppercase text-red-600 animate-pulse">Maximum length reached</span>
-                    )}
-                  </div>
-                  <input
-                    type="tel"
-                    value={accountForm.phone}
-                    onChange={(e) => handleAccountChange("phone", e.target.value)}
-                    className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
-                  />
-                </div>
-                <div>
-                  <div className="flex justify-between items-end mb-2">
-                    <label className="block text-sm font-medium text-gray-700">Email Address *</label>
-                    {attemptedExceed.email && (
-                      <span className="text-[10px] font-bold uppercase text-red-600 animate-pulse">Maximum length reached</span>
-                    )}
-                  </div>
-                  <input
-                    type="email"
-                    value={accountForm.email}
-                    onChange={(e) => handleAccountChange("email", e.target.value)}
-                    className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
-                    required
-                  />
-                </div>
-
-                {accountForm.email !== originalEmail && (
-                  <div className="bg-amber-50 p-4 rounded-xl border border-amber-100">
-                    <label className="block text-sm font-medium text-amber-900 mb-2">
-                      Confirm Password to Change Email
-                    </label>
-                    <input
-                      type="password"
-                      value={accountForm.currentPassword}
-                      onChange={(e) => handleAccountChange("currentPassword", e.target.value)}
-                      placeholder="Enter your current password"
-                      className="w-full rounded-xl border border-amber-200 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
-                      required
-                    />
-                    <p className="mt-2 text-xs text-amber-700">
-                      For your security, you must provide your current password to update your email address.
-                    </p>
-                  </div>
-                )}
-
-                <div className="mt-2">
-                  <button
-                    type="submit"
-                    disabled={savingAccount}
-                    className="rounded-xl bg-blue-600 px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-white transition hover:bg-blue-700 disabled:opacity-50"
-                  >
-                    {savingAccount ? "Saving..." : "Save Account Info"}
-                  </button>
-                </div>
-              </form>
+                ))}
+              </div>
             )}
+
+            <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+              <DialogContent className="sm:max-w-[425px]">
+                <form onSubmit={handleDialogSave}>
+                  <DialogHeader>
+                    <DialogTitle>Edit {editingField === "company_name" ? "Company Name" : editingField === "phone" ? "Phone Number" : "Email Address"}</DialogTitle>
+                  </DialogHeader>
+                  <div className="grid gap-4 py-4">
+                    <div className="grid gap-2">
+                      <div className="flex justify-between items-center">
+                        <Label htmlFor="tempValue">
+                          {editingField === "company_name" ? "Company Name" : editingField === "phone" ? "Phone Number" : "Email Address"}
+                        </Label>
+                        {editingField && tempValue.length >= ACCOUNT_INFO_FIELD_LIMITS[editingField] && (
+                          <span className="text-[10px] font-bold uppercase text-red-600 animate-pulse">Max length reached</span>
+                        )}
+                      </div>
+                      <Input
+                        id="tempValue"
+                        type={editingField === "email" ? "email" : editingField === "phone" ? "tel" : "text"}
+                        value={tempValue}
+                        onChange={(e) => {
+                          const val = e.target.value;
+                          if (editingField) {
+                            const limit = ACCOUNT_INFO_FIELD_LIMITS[editingField];
+                            if (limit && val.length > limit) return;
+                          }
+                          setTempValue(val);
+                        }}
+                        className="col-span-3"
+                        required={editingField !== "phone"}
+                      />
+                    </div>
+                    <div className="grid gap-2">
+                      <Label htmlFor="tempPassword">Current Password</Label>
+                      <Input
+                        id="tempPassword"
+                        type="password"
+                        value={tempPassword}
+                        onChange={(e) => setTempPassword(e.target.value)}
+                        placeholder="Confirm with your password"
+                        className="col-span-3"
+                        required
+                      />
+                    </div>
+                  </div>
+                  <DialogFooter>
+                    <Button type="button" variant="outline" onClick={() => setIsDialogOpen(false)} disabled={savingAccount}>
+                      Cancel
+                    </Button>
+                    <Button type="submit" disabled={savingAccount}>
+                      {savingAccount ? "Saving..." : "Save Changes"}
+                    </Button>
+                  </DialogFooter>
+                </form>
+              </DialogContent>
+            </Dialog>
           </div>
         )}
 

--- a/app/account-settings/page.tsx
+++ b/app/account-settings/page.tsx
@@ -46,6 +46,7 @@ function AccountSettingsContent() {
   const [editingField, setEditingField] = useState<AccountInfoField | null>(null);
   const [tempValue, setTempValue] = useState("");
   const [tempPassword, setTempPassword] = useState("");
+  const [dialogError, setDialogError] = useState("");
 
   const [attemptedExceed, setAttemptedExceed] = useState<Partial<Record<BillingField | AccountInfoField, boolean>>>({});
 
@@ -117,6 +118,7 @@ function AccountSettingsContent() {
     setEditingField(field);
     setTempValue(accountForm[field] || "");
     setTempPassword("");
+    setDialogError("");
     setIsDialogOpen(true);
     setAccountMessage({ type: "", text: "" });
   };
@@ -125,8 +127,16 @@ function AccountSettingsContent() {
     event.preventDefault();
     if (!editingField) return;
 
+    const hasChanged = tempValue !== (accountForm[editingField] || "");
+    
+    // If no change and no password, just close without message
+    if (!hasChanged && !tempPassword) {
+      setIsDialogOpen(false);
+      return;
+    }
+
     setSavingAccount(true);
-    setAccountMessage({ type: "", text: "" });
+    setDialogError("");
 
     // Build the payload with the updated field and current values for others
     const payload = {
@@ -144,11 +154,13 @@ function AccountSettingsContent() {
 
       const data = await response.json();
       if (!response.ok) {
-        setAccountMessage({ type: "error", text: data?.error || "Unable to save account info." });
+        setDialogError(data?.error || "Unable to save account info.");
         return;
       }
 
-      setAccountMessage({ type: "success", text: "Account information saved successfully." });
+      if (hasChanged) {
+        setAccountMessage({ type: "success", text: "Account information saved successfully." });
+      }
       
       // Update local state
       setAccountForm(prev => ({
@@ -165,7 +177,7 @@ function AccountSettingsContent() {
       
       setIsDialogOpen(false);
     } catch {
-      setAccountMessage({ type: "error", text: "Unable to save account info." });
+      setDialogError("Unable to save account info.");
     } finally {
       setSavingAccount(false);
     }
@@ -314,6 +326,11 @@ function AccountSettingsContent() {
                     </div>
                     
                     <div className="px-6 py-4 space-y-4">
+                      {dialogError && (
+                        <div className="bg-red-50 text-red-700 p-3 rounded-lg text-sm border border-red-100">
+                          {dialogError}
+                        </div>
+                      )}
                       <div>
                         <div className="flex justify-between items-center mb-1">
                           <label className="block text-sm font-medium text-gray-700">
@@ -352,7 +369,6 @@ function AccountSettingsContent() {
                           onChange={(e) => setTempPassword(e.target.value)}
                           placeholder="Confirm with your password"
                           className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
-                          required
                           autoComplete="current-password"
                         />
                       </div>

--- a/app/account-settings/page.tsx
+++ b/app/account-settings/page.tsx
@@ -4,10 +4,10 @@ import { useSession, signOut } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import Header from "@/components/Header";
-import { BILLING_FIELD_LIMITS, BillingField } from "@/lib/field-limits";
+import { BILLING_FIELD_LIMITS, BillingField, ACCOUNT_INFO_FIELD_LIMITS, AccountInfoField } from "@/lib/field-limits";
 
 function AccountSettingsContent() {
-  const { data: session, status } = useSession();
+  const { data: session, status, update } = useSession();
   const router = useRouter();
   const [billingLoading, setBillingLoading] = useState(false);
   const [savingBilling, setSavingBilling] = useState(false);
@@ -19,7 +19,19 @@ function AccountSettingsContent() {
     billing_state: "",
     billing_postal_code: "",
   });
-  const [attemptedExceed, setAttemptedExceed] = useState<Partial<Record<BillingField, boolean>>>({});
+
+  const [accountLoading, setAccountLoading] = useState(false);
+  const [savingAccount, setSavingAccount] = useState(false);
+  const [accountMessage, setAccountMessage] = useState({ type: "", text: "" });
+  const [accountForm, setAccountForm] = useState({
+    company_name: "",
+    phone: "",
+    email: "",
+    currentPassword: "",
+  });
+  const [originalEmail, setOriginalEmail] = useState("");
+
+  const [attemptedExceed, setAttemptedExceed] = useState<Partial<Record<BillingField | AccountInfoField, boolean>>>({});
 
   const userType = (session?.user as { user_type?: string } | undefined)?.user_type;
   const firstName = (session?.user as { first_name?: string } | undefined)?.first_name;
@@ -32,9 +44,10 @@ function AccountSettingsContent() {
   }, [status, router]);
 
   useEffect(() => {
-    const loadBilling = async () => {
+    const loadData = async () => {
       if (status !== "authenticated" || userType !== "client") return;
       setBillingLoading(true);
+      setAccountLoading(true);
       try {
         const response = await fetch("/api/clients/me", { cache: "no-store" });
         if (!response.ok) return;
@@ -46,14 +59,23 @@ function AccountSettingsContent() {
           billing_state: payload.billing_state || "",
           billing_postal_code: payload.billing_postal_code || "",
         });
+        setAccountForm({
+          company_name: payload.company_name || "",
+          phone: payload.phone || "",
+          email: payload.email || "",
+          currentPassword: "",
+        });
+        setOriginalEmail(payload.email || "");
       } catch {
         setBillingMessage({ type: "error", text: "Unable to load billing address." });
+        setAccountMessage({ type: "error", text: "Unable to load account information." });
       } finally {
         setBillingLoading(false);
+        setAccountLoading(false);
       }
     };
 
-    loadBilling();
+    loadData();
   }, [status, userType]);
 
   const handleBillingChange = (field: BillingField, value: string) => {
@@ -72,6 +94,60 @@ function AccountSettingsContent() {
     // If they delete characters, reset the "attempted to exceed" state
     if (!isAtLimit) {
       setAttemptedExceed((prev) => ({ ...prev, [field]: false }));
+    }
+  };
+
+  const handleAccountChange = (field: AccountInfoField | 'currentPassword', value: string) => {
+    if (field !== 'currentPassword') {
+      const limit = ACCOUNT_INFO_FIELD_LIMITS[field as AccountInfoField];
+      if (limit && value.length > limit) {
+        if (!attemptedExceed[field as AccountInfoField]) {
+          setAttemptedExceed((prev) => ({ ...prev, [field]: true }));
+        }
+        return;
+      }
+      
+      const isAtLimit = limit ? value.length >= limit : false;
+      if (!isAtLimit) {
+        setAttemptedExceed((prev) => ({ ...prev, [field as AccountInfoField]: false }));
+      }
+    }
+
+    setAccountForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleAccountSave = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setSavingAccount(true);
+    setAccountMessage({ type: "", text: "" });
+
+    try {
+      const response = await fetch("/api/clients/me", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(accountForm),
+      });
+
+      const payload = await response.json();
+      if (!response.ok) {
+        setAccountMessage({ type: "error", text: payload?.error || "Unable to save account info." });
+        return;
+      }
+
+      setAccountMessage({ type: "success", text: "Account information saved successfully." });
+      
+      // If email changed, update the session
+      if (accountForm.email !== originalEmail) {
+        await update({ email: accountForm.email });
+        setOriginalEmail(accountForm.email);
+      }
+      
+      // Clear password field
+      setAccountForm(prev => ({ ...prev, currentPassword: "" }));
+    } catch {
+      setAccountMessage({ type: "error", text: "Unable to save account info." });
+    } finally {
+      setSavingAccount(false);
     }
   };
 
@@ -159,6 +235,106 @@ function AccountSettingsContent() {
             {backLabel}
           </a>
         </div>
+
+        {/* Account Info */}
+        {userType === "client" && (
+          <div className="bg-white p-6 rounded-xl border border-gray-200 shadow-sm mb-8">
+            <h2 className="font-display text-3xl text-gray-900 mb-2">Account Info</h2>
+            <p className="text-gray-600 mb-6">Update your basic account details.</p>
+
+            {accountMessage.text && (
+              <div
+                className={`mb-4 rounded-lg p-3 text-sm ${
+                  accountMessage.type === "success"
+                    ? "bg-emerald-50 text-emerald-700"
+                    : "bg-red-50 text-red-700"
+                }`}
+              >
+                {accountMessage.text}
+              </div>
+            )}
+
+            {accountLoading ? (
+              <p className="text-gray-600">Loading account information...</p>
+            ) : (
+              <form onSubmit={handleAccountSave} className="grid gap-4">
+                <div>
+                  <div className="flex justify-between items-end mb-2">
+                    <label className="block text-sm font-medium text-gray-700">Company Name *</label>
+                    {attemptedExceed.company_name && (
+                      <span className="text-[10px] font-bold uppercase text-red-600 animate-pulse">Maximum length reached</span>
+                    )}
+                  </div>
+                  <input
+                    type="text"
+                    value={accountForm.company_name}
+                    onChange={(e) => handleAccountChange("company_name", e.target.value)}
+                    className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                    required
+                  />
+                </div>
+                <div>
+                  <div className="flex justify-between items-end mb-2">
+                    <label className="block text-sm font-medium text-gray-700">Phone Number</label>
+                    {attemptedExceed.phone && (
+                      <span className="text-[10px] font-bold uppercase text-red-600 animate-pulse">Maximum length reached</span>
+                    )}
+                  </div>
+                  <input
+                    type="tel"
+                    value={accountForm.phone}
+                    onChange={(e) => handleAccountChange("phone", e.target.value)}
+                    className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                  />
+                </div>
+                <div>
+                  <div className="flex justify-between items-end mb-2">
+                    <label className="block text-sm font-medium text-gray-700">Email Address *</label>
+                    {attemptedExceed.email && (
+                      <span className="text-[10px] font-bold uppercase text-red-600 animate-pulse">Maximum length reached</span>
+                    )}
+                  </div>
+                  <input
+                    type="email"
+                    value={accountForm.email}
+                    onChange={(e) => handleAccountChange("email", e.target.value)}
+                    className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                    required
+                  />
+                </div>
+
+                {accountForm.email !== originalEmail && (
+                  <div className="bg-amber-50 p-4 rounded-xl border border-amber-100">
+                    <label className="block text-sm font-medium text-amber-900 mb-2">
+                      Confirm Password to Change Email
+                    </label>
+                    <input
+                      type="password"
+                      value={accountForm.currentPassword}
+                      onChange={(e) => handleAccountChange("currentPassword", e.target.value)}
+                      placeholder="Enter your current password"
+                      className="w-full rounded-xl border border-amber-200 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                      required
+                    />
+                    <p className="mt-2 text-xs text-amber-700">
+                      For your security, you must provide your current password to update your email address.
+                    </p>
+                  </div>
+                )}
+
+                <div className="mt-2">
+                  <button
+                    type="submit"
+                    disabled={savingAccount}
+                    className="rounded-xl bg-blue-600 px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-white transition hover:bg-blue-700 disabled:opacity-50"
+                  >
+                    {savingAccount ? "Saving..." : "Save Account Info"}
+                  </button>
+                </div>
+              </form>
+            )}
+          </div>
+        )}
 
         {/* Change Password */}
         {userType === "client" && (

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -80,18 +80,24 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     }),
   ],
   callbacks: {
-    async jwt({ token, user }) {
+    async jwt({ token, user, trigger, session }) {
       if (user) {
         token.id = user.id;
         token.user_type = (user as { user_type?: string }).user_type || "client";
         token.first_name = (user as { first_name?: string }).first_name ?? "";
         token.last_name = (user as { last_name?: string }).last_name ?? "";
       }
+
+      if (trigger === "update" && session?.email) {
+        token.email = session.email;
+      }
+
       return token;
     },
     async session({ session, token }) {
       if (session.user) {
         session.user.id = token.id as string;
+        session.user.email = token.email as string || session.user.email;
         (session.user as { user_type?: string }).user_type =
           typeof token.user_type === "string" ? token.user_type : "client";
         (session.user as { first_name?: string }).first_name =

--- a/app/api/auth/change-email/route.ts
+++ b/app/api/auth/change-email/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { decryptToken } from "@/lib/crypto";
+import { sql } from "@/lib/db";
+import { persistApiError } from "@/lib/error-logger";
+
+export async function POST(request: Request) {
+  try {
+    const { sec_token, email } = await request.json();
+
+    if (!sec_token) {
+      return NextResponse.json({ error: "Security token is required." }, { status: 400 });
+    }
+
+    if (!email) {
+      return NextResponse.json({ error: "Email is required." }, { status: 400 });
+    }
+
+    let payload;
+    try {
+      const decrypted = decryptToken(sec_token);
+      payload = JSON.parse(decrypted);
+    } catch {
+      return NextResponse.json({ error: "Invalid security token." }, { status: 400 });
+    }
+
+    const { userId, timestamp } = payload;
+
+    if (!userId || !timestamp) {
+      return NextResponse.json({ error: "Malformed security token." }, { status: 400 });
+    }
+
+    // Token expires after 24 hours
+    const now = Date.now();
+    const age = now - timestamp;
+    if (age > 24 * 60 * 60 * 1000) {
+      return NextResponse.json({ error: "Security token has expired." }, { status: 400 });
+    }
+
+    // Update the email in the DB
+    await sql`
+      UPDATE clients
+      SET email = ${email}, updated_at = NOW()
+      WHERE id = ${userId}
+    `;
+
+    return NextResponse.json({ success: true, message: "Email updated successfully." });
+  } catch (error: unknown) {
+    await persistApiError({
+      route: "/api/auth/change-email",
+      method: "POST",
+      statusCode: 500,
+      error,
+    });
+    const message = error instanceof Error ? error.message : "Internal server error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/auth/change-password/route.ts
+++ b/app/api/auth/change-password/route.ts
@@ -179,8 +179,10 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
     }
 
+    const userEmail = session?.user?.email || (updated as { email?: string }).email;
+
     // Send security notification email via Resend
-    if (resend && contactFromEmail && session?.user?.email) {
+    if (resend && contactFromEmail && userEmail) {
       try {
         const origin = req.nextUrl.origin;
         const secToken = encryptToken(JSON.stringify({ userId: rawUserId, timestamp: Date.now() }));
@@ -188,7 +190,7 @@ export async function POST(req: NextRequest) {
         
         await resend.emails.send({
           from: contactFromEmail,
-          to: session.user.email,
+          to: userEmail,
           replyTo: process.env.CONTACT_TO_EMAIL || "hello@clearsiteconsultants.com",
           subject: "Security Alert: Password Changed",
           text: `Security Alert: Your password was recently changed. If you did not perform this action, please visit the following link to reset it again immediately: ${changePasswordUrl}`,

--- a/app/api/clients/me/route.ts
+++ b/app/api/clients/me/route.ts
@@ -1,10 +1,15 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/app/api/auth/[...nextauth]/route";
-import { getQuickBooksConnection, sql, updateClientBillingAddress } from "@/lib/db";
+import { getQuickBooksConnection, sql, updateClientBillingAddress, updateClientAccountInfo, getClientById } from "@/lib/db";
 import { updateQuickBooksCustomerBillingAddress } from "@/lib/quickbooks";
 import { syncClientInvoicesFromQuickBooks } from "@/lib/quickbooks-sync";
 import { persistApiError } from "@/lib/error-logger";
-import { BILLING_FIELD_LIMITS } from "@/lib/field-limits";
+import { BILLING_FIELD_LIMITS, ACCOUNT_INFO_FIELD_LIMITS } from "@/lib/field-limits";
+import { verifyPassword } from "@/lib/password-utils";
+import { encryptToken } from "@/lib/crypto";
+import { Resend } from "resend";
+
+const resend = process.env.RESEND_API_KEY ? new Resend(process.env.RESEND_API_KEY) : null;
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -15,6 +20,13 @@ type BillingAddressPayload = {
   billing_city?: string | null;
   billing_state?: string | null;
   billing_postal_code?: string | null;
+};
+
+type AccountInfoPayload = {
+  company_name?: string;
+  phone?: string | null;
+  email?: string;
+  currentPassword?: string;
 };
 
 function parseClientId(sessionUserId: string) {
@@ -59,6 +71,10 @@ async function ensureClientProfileColumns() {
   await sql`
     ALTER TABLE clients
     ADD COLUMN IF NOT EXISTS last_name VARCHAR(255) NOT NULL DEFAULT ''
+  `;
+  await sql`
+    ALTER TABLE clients
+    ADD COLUMN IF NOT EXISTS phone VARCHAR(50)
   `;
   await sql`
     ALTER TABLE clients
@@ -122,6 +138,7 @@ async function getClientProfile(clientId: string) {
         company_name,
         first_name,
         last_name,
+        phone,
         domain_name,
         plan,
         service_status,
@@ -153,6 +170,7 @@ async function getClientProfile(clientId: string) {
         company_name,
         first_name,
         last_name,
+        phone,
         domain_name,
         plan,
         service_status,
@@ -329,10 +347,138 @@ async function updateBillingAddress(request: Request) {
   }
 }
 
+async function updateAccountInfo(request: Request) {
+  const session = await auth();
+  const userType = (session?.user as { user_type?: string } | undefined)?.user_type;
+
+  if (!session?.user?.id || userType !== "client") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const clientId = parseClientId(session.user.id as string);
+  if (!clientId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const payload = await request.json() as AccountInfoPayload;
+    const client = await getClientById(clientId);
+
+    if (!client) {
+      return NextResponse.json({ error: "Client not found" }, { status: 404 });
+    }
+
+    const normalizedEmail = normalizeTextField(payload.email);
+    const normalizedCompany = normalizeTextField(payload.company_name);
+    const normalizedPhone = normalizeTextField(payload.phone);
+
+    if (!normalizedEmail || !normalizedCompany) {
+      return NextResponse.json({ error: "Email and Company Name are required." }, { status: 400 });
+    }
+
+    // Validation
+    if (normalizedEmail.length > ACCOUNT_INFO_FIELD_LIMITS.email) {
+      return NextResponse.json({ error: "Email exceeds character limit." }, { status: 400 });
+    }
+    if (normalizedCompany.length > ACCOUNT_INFO_FIELD_LIMITS.company_name) {
+      return NextResponse.json({ error: "Company Name exceeds character limit." }, { status: 400 });
+    }
+    if (normalizedPhone && normalizedPhone.length > ACCOUNT_INFO_FIELD_LIMITS.phone) {
+      return NextResponse.json({ error: "Phone Number exceeds character limit." }, { status: 400 });
+    }
+
+    // Email change requires re-authentication
+    if (normalizedEmail !== client.email) {
+      if (!payload.currentPassword) {
+        return NextResponse.json({ error: "Password is required to change email address." }, { status: 400 });
+      }
+
+      const { valid } = await verifyPassword(payload.currentPassword, client.password_hash);
+      if (!valid) {
+        return NextResponse.json({ error: "Incorrect password." }, { status: 401 });
+      }
+
+      // Send Security Alert to OLD email
+      if (resend) {
+        const secToken = encryptToken(JSON.stringify({
+          userId: clientId,
+          oldEmail: client.email,
+          timestamp: Date.now()
+        }));
+
+        const protocol = process.env.NEXTAUTH_URL?.startsWith('https') ? 'https' : 'http';
+        const host = process.env.NEXTAUTH_URL?.split('://')[1] || 'localhost:3000';
+        const recoveryUrl = `${protocol}://${host}/change-email?sec_token=${encodeURIComponent(secToken)}`;
+
+        try {
+          await resend.emails.send({
+            from: process.env.CONTACT_FROM_EMAIL || "security@clearsiteconsultants.com",
+            to: client.email,
+            subject: "Security Alert: Email Address Changed",
+            text: `Security Alert: Your email address was recently changed. If you did not perform this action, please visit the following link to restore it immediately: ${recoveryUrl}. We also recommend that you change your password.`,
+            html: `
+              <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #e2e8f0; border-radius: 12px;">
+                <h2 style="color: #1e293b;">Security Alert</h2>
+                <p>Your email address was recently changed. If you did not perform this action, please visit the link below to restore it immediately.</p>
+                <div style="margin: 30px 0;">
+                  <a href="${recoveryUrl}" style="background-color: #2563eb; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: 600;">Change Email Address</a>
+                </div>
+                <p>We also recommend that you change your password to secure your account.</p>
+                <p style="color: #64748b; font-size: 14px;">This is an automated security notification.</p>
+              </div>
+            `
+          });
+        } catch (emailError) {
+          console.error("[api/clients/me] Failed to send security alert email", emailError);
+          // We continue anyway, but maybe we should log this.
+        }
+      }
+    }
+
+    const updatedClient = await updateClientAccountInfo(clientId, {
+      company_name: normalizedCompany,
+      phone: normalizedPhone,
+      email: normalizedEmail,
+    });
+
+    return NextResponse.json(updatedClient);
+  } catch (error: unknown) {
+    await persistApiError({
+      route: "/api/clients/me",
+      method: "PUT",
+      statusCode: 500,
+      userId: String(session.user.id),
+      userType: userType ?? null,
+      error,
+      metadata: { clientId },
+    });
+    const message = error instanceof Error ? error.message : "Internal server error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
 export async function PUT(request: Request) {
-  return updateBillingAddress(request);
+  const clonedRequest = request.clone();
+  try {
+    const payload = await clonedRequest.json();
+    if ('company_name' in payload || 'email' in payload) {
+      return updateAccountInfo(request);
+    }
+    return updateBillingAddress(request);
+  } catch {
+    return updateBillingAddress(request);
+  }
 }
 
 export async function PATCH(request: Request) {
-  return updateBillingAddress(request);
+  const clonedRequest = request.clone();
+  try {
+    const payload = await clonedRequest.json();
+    if ('company_name' in payload || 'email' in payload) {
+      return updateAccountInfo(request);
+    }
+    return updateBillingAddress(request);
+  } catch {
+    return updateBillingAddress(request);
+  }
 }

--- a/app/api/clients/me/route.ts
+++ b/app/api/clients/me/route.ts
@@ -387,10 +387,10 @@ async function updateAccountInfo(request: Request) {
       return NextResponse.json({ error: "Phone Number exceeds character limit." }, { status: 400 });
     }
 
-    // Email change requires re-authentication
-    if (normalizedEmail !== client.email) {
+    // Account info changes require re-authentication
+    if (normalizedEmail !== client.email || normalizedCompany !== client.company_name || normalizedPhone !== client.phone) {
       if (!payload.currentPassword) {
-        return NextResponse.json({ error: "Password is required to change email address." }, { status: 400 });
+        return NextResponse.json({ error: "Password is required to update account information." }, { status: 400 });
       }
 
       const { valid } = await verifyPassword(payload.currentPassword, client.password_hash);
@@ -398,8 +398,8 @@ async function updateAccountInfo(request: Request) {
         return NextResponse.json({ error: "Incorrect password." }, { status: 401 });
       }
 
-      // Send Security Alert to OLD email
-      if (resend) {
+      // Send Security Alert to OLD email (only if email changed)
+      if (normalizedEmail !== client.email && resend) {
         const secToken = encryptToken(JSON.stringify({
           userId: clientId,
           oldEmail: client.email,

--- a/app/api/clients/me/route.ts
+++ b/app/api/clients/me/route.ts
@@ -387,8 +387,10 @@ async function updateAccountInfo(request: Request) {
       return NextResponse.json({ error: "Phone Number exceeds character limit." }, { status: 400 });
     }
 
-    // Account info changes require re-authentication
-    if (normalizedEmail !== client.email || normalizedCompany !== client.company_name || normalizedPhone !== client.phone) {
+    // Account info changes or password verification
+    const hasInfoChange = normalizedEmail !== client.email || normalizedCompany !== client.company_name || normalizedPhone !== client.phone;
+    
+    if (hasInfoChange || payload.currentPassword) {
       if (!payload.currentPassword) {
         return NextResponse.json({ error: "Password is required to update account information." }, { status: 400 });
       }

--- a/app/change-email/page.tsx
+++ b/app/change-email/page.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useSearchParams, useRouter } from "next/navigation";
+import { useEffect, useState, Suspense } from "react";
+import Header from "@/components/Header";
+
+function ChangeEmailContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const [secToken, setSecToken] = useState<string | null>(null);
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState({ type: "", text: "" });
+  const [success, setSuccess] = useState(false);
+
+  useEffect(() => {
+    const token = searchParams.get("sec_token");
+    if (token) {
+      setSecToken(token);
+    } else {
+      setMessage({ type: "error", text: "Invalid or missing security token." });
+    }
+  }, [searchParams]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!secToken) return;
+
+    setLoading(true);
+    setMessage({ type: "", text: "" });
+
+    try {
+      const response = await fetch("/api/auth/change-email", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sec_token: secToken,
+          email: email,
+        }),
+      });
+
+      const payload = await response.json();
+
+      if (!response.ok) {
+        setMessage({ type: "error", text: payload.error || "Failed to update email address." });
+        return;
+      }
+
+      setSuccess(true);
+      setMessage({ type: "success", text: "Email address updated successfully. You can now log in with your new email." });
+      
+      // Redirect to login after 3 seconds
+      setTimeout(() => {
+        router.push("/login");
+      }, 3000);
+    } catch {
+      setMessage({ type: "error", text: "An error occurred while updating your email." });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-tech">
+      <Header />
+      <div className="max-w-md mx-auto px-6 py-24">
+        <div className="bg-white p-8 rounded-2xl border border-gray-200 shadow-sm">
+          <h1 className="font-display text-4xl text-gray-900 mb-6 text-center">Update Email</h1>
+          
+          {message.text && (
+            <div className={`mb-6 p-4 rounded-xl text-sm ${
+              message.type === "success" ? "bg-emerald-50 text-emerald-700 border border-emerald-100" : "bg-red-50 text-red-700 border border-red-100"
+            }`}>
+              {message.text}
+            </div>
+          )}
+
+          {!success && secToken && (
+            <form onSubmit={handleSubmit} className="space-y-6">
+              <p className="text-gray-600 text-sm">
+                Enter the email address you would like to use for your account. This action does not require your current password because you validated it via email.
+              </p>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">New Email Address</label>
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="name@company.com"
+                  className="w-full rounded-xl border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                  required
+                />
+              </div>
+              <button
+                type="submit"
+                disabled={loading}
+                className="w-full rounded-xl bg-blue-600 py-4 text-sm font-bold uppercase tracking-[0.2em] text-white transition hover:bg-blue-700 disabled:opacity-50 shadow-lg shadow-blue-200"
+              >
+                {loading ? "Updating..." : "Update Email Address"}
+              </button>
+            </form>
+          )}
+
+          {!secToken && !message.text && (
+            <div className="text-center">
+              <p className="text-gray-600 mb-6">No security token found. Please use the link provided in your security alert email.</p>
+              <button
+                onClick={() => router.push("/login")}
+                className="text-blue-600 font-semibold hover:underline"
+              >
+                Back to Login
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ChangeEmailPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen bg-tech flex items-center justify-center">
+        <div className="w-16 h-16 border-4 border-blue-600 border-t-transparent rounded-full animate-spin"></div>
+      </div>
+    }>
+      <ChangeEmailContent />
+    </Suspense>
+  );
+}

--- a/app/change-password/page.tsx
+++ b/app/change-password/page.tsx
@@ -72,9 +72,15 @@ function ChangePasswordContent() {
       setPasswordMessage({ type: "success", text: "Password updated successfully." });
       setPasswordForm({ newPassword: "", confirmPassword: "" });
       
-      // If they used a sec_token (not logged in), redirect to login after success
-      if (!session) {
-        setTimeout(() => router.push("/login"), 3000);
+      if (secToken) {
+        // If they used a sec_token (Security Alert), keep original behavior:
+        // redirect to login after success only if not currently logged in.
+        if (!session) {
+          setTimeout(() => router.push("/login"), 3000);
+        }
+      } else {
+        // Otherwise (changing from account settings), redirect to portal
+        setTimeout(() => router.push("/portal"), 3000);
       }
     } catch (error) {
       setPasswordMessage({
@@ -131,8 +137,11 @@ function ChangePasswordContent() {
               }`}
             >
               {passwordMessage.text}
-              {passwordMessage.type === "success" && !session && (
+              {passwordMessage.type === "success" && secToken && !session && (
                 <p className="mt-2">Redirecting to login...</p>
+              )}
+              {passwordMessage.type === "success" && !secToken && (
+                <p className="mt-2">Redirecting to portal...</p>
               )}
             </div>
           )}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -866,6 +866,44 @@ export async function getClientBillingAddress(clientId: string) {
   return result.rows[0];
 }
 
+export async function updateClientAccountInfo(
+  clientId: string,
+  data: {
+    company_name: string;
+    phone: string | null;
+    email: string;
+  }
+) {
+  const result = await sql`
+    UPDATE clients
+    SET
+      company_name = ${data.company_name},
+      phone = ${data.phone},
+      email = ${data.email},
+      updated_at = NOW()
+    WHERE id = ${clientId}
+    RETURNING
+      id,
+      email,
+      company_name,
+      first_name,
+      last_name,
+      phone,
+      domain_name,
+      plan,
+      service_status,
+      next_invoice_due,
+      qbo_customer_id,
+      billing_address_line1,
+      billing_address_line2,
+      billing_city,
+      billing_state,
+      billing_postal_code,
+      billing_country
+  `;
+  return result.rows[0];
+}
+
 export async function updateClientBillingAddress(
   clientId: string,
   data: {

--- a/lib/field-limits.ts
+++ b/lib/field-limits.ts
@@ -8,8 +8,22 @@ export const BILLING_FIELD_LIMITS = {
 
 export type BillingField = keyof typeof BILLING_FIELD_LIMITS;
 
-export function isFieldAtLimit(field: BillingField, value: string): boolean {
-  return value.length >= BILLING_FIELD_LIMITS[field];
+export const ACCOUNT_INFO_FIELD_LIMITS = {
+  company_name: 255,
+  phone: 50,
+  email: 255,
+} as const;
+
+export type AccountInfoField = keyof typeof ACCOUNT_INFO_FIELD_LIMITS;
+
+export function isFieldAtLimit(field: BillingField | AccountInfoField, value: string): boolean {
+  if (field in BILLING_FIELD_LIMITS) {
+    return value.length >= BILLING_FIELD_LIMITS[field as BillingField];
+  }
+  if (field in ACCOUNT_INFO_FIELD_LIMITS) {
+    return value.length >= ACCOUNT_INFO_FIELD_LIMITS[field as AccountInfoField];
+  }
+  return false;
 }
 
 export const INVOICE_FIELD_LIMITS = {

--- a/tests/app/api/clients.me.route.test.ts
+++ b/tests/app/api/clients.me.route.test.ts
@@ -7,6 +7,9 @@ const {
   getQuickBooksConnectionMock,
   updateQuickBooksCustomerBillingAddressMock,
   syncClientInvoicesFromQuickBooksMock,
+  createErrorLogMock,
+  getClientByIdMock,
+  updateClientAccountInfoMock,
 } = vi.hoisted(() => ({
   authMock: vi.fn(),
   sqlMock: vi.fn(),
@@ -14,6 +17,9 @@ const {
   getQuickBooksConnectionMock: vi.fn(),
   updateQuickBooksCustomerBillingAddressMock: vi.fn(),
   syncClientInvoicesFromQuickBooksMock: vi.fn(),
+  createErrorLogMock: vi.fn(),
+  getClientByIdMock: vi.fn(),
+  updateClientAccountInfoMock: vi.fn(),
 }));
 
 vi.mock("@/app/api/auth/[...nextauth]/route", () => ({ auth: authMock }));
@@ -22,6 +28,9 @@ vi.mock("@/lib/db", () => ({
   sql: sqlMock,
   updateClientBillingAddress: updateClientBillingAddressMock,
   getQuickBooksConnection: getQuickBooksConnectionMock,
+  createErrorLog: createErrorLogMock,
+  getClientById: getClientByIdMock,
+  updateClientAccountInfo: updateClientAccountInfoMock,
 }));
 
 vi.mock("@/lib/quickbooks", () => ({
@@ -69,7 +78,8 @@ describe("/api/clients/me", () => {
     sqlMock
       // Initial SELECT fails due to missing billing column
       .mockRejectedValueOnce(new Error('column "billing_address_line1" does not exist'))
-      // ensureClientProfileColumns: 8 ALTER TABLE calls, all resolve with empty rows
+      // ensureClientProfileColumns: 9 ALTER TABLE calls, all resolve with empty rows
+      .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })

--- a/tests/app/api/clients.me.route.test.ts
+++ b/tests/app/api/clients.me.route.test.ts
@@ -10,6 +10,7 @@ const {
   createErrorLogMock,
   getClientByIdMock,
   updateClientAccountInfoMock,
+  verifyPasswordMock,
 } = vi.hoisted(() => ({
   authMock: vi.fn(),
   sqlMock: vi.fn(),
@@ -20,6 +21,7 @@ const {
   createErrorLogMock: vi.fn(),
   getClientByIdMock: vi.fn(),
   updateClientAccountInfoMock: vi.fn(),
+  verifyPasswordMock: vi.fn(),
 }));
 
 vi.mock("@/app/api/auth/[...nextauth]/route", () => ({ auth: authMock }));
@@ -31,6 +33,10 @@ vi.mock("@/lib/db", () => ({
   createErrorLog: createErrorLogMock,
   getClientById: getClientByIdMock,
   updateClientAccountInfo: updateClientAccountInfoMock,
+}));
+
+vi.mock("@/lib/password-utils", () => ({
+  verifyPassword: verifyPasswordMock,
 }));
 
 vi.mock("@/lib/quickbooks", () => ({
@@ -257,5 +263,33 @@ describe("/api/clients/me", () => {
     const payload = await response.json();
     expect(response.status).toBe(400);
     expect(payload.error).toContain("State must be a 2-letter uppercase code");
+  });
+
+  it("verifies password even if account info hasn't changed if a password is provided", async () => {
+    getClientByIdMock.mockResolvedValue({
+      id: "1",
+      email: "client@example.com",
+      company_name: "Acme",
+      phone: "555-1234",
+      password_hash: "hashed_password",
+    });
+
+    verifyPasswordMock.mockResolvedValue({ valid: false });
+
+    const response = await PUT(new Request("http://localhost:3000/api/clients/me", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "client@example.com",
+        company_name: "Acme",
+        phone: "555-1234",
+        currentPassword: "wrong_password"
+      }),
+    }));
+
+    const payload = await response.json();
+    expect(response.status).toBe(401);
+    expect(payload.error).toBe("Incorrect password.");
+    expect(verifyPasswordMock).toHaveBeenCalledWith("wrong_password", "hashed_password");
   });
 });


### PR DESCRIPTION
Implemented Account Info section in client settings.
- Added Company Name, Phone, and Email fields.
- Required re-authentication (current password) for email changes.
- Implemented security alert email system:
  - If email is changed, a security alert is sent to the OLD email.
  - Included a token-based recovery link in the email.
  - Alert recommends password change.
- Added /change-email recovery page.
- Updated session handling to refresh email after change.

Closes #35