### PR TITLE
Feat: Add QuickBooks invoice email sending functionality and related tests (Issue #40)

### DIFF
--- a/app/portal/page.tsx
+++ b/app/portal/page.tsx
@@ -321,9 +321,20 @@ export default function Portal() {
                               </div>
                             ) : isUnpaid && !paymentUrl ? (
                               <>
-                                <Button size="sm" disabled className="h-8 w-fit px-3 text-xs tracking-[0.12em]">
-                                  PAY NOW
-                                </Button>
+                                <div className="flex items-center gap-3">
+                                  <Button size="sm" disabled className="h-8 w-fit px-3 text-xs tracking-[0.12em]">
+                                    <a
+                                      href="#"
+                                      aria-label="Pay invoice with QuickBooks (contact support for payment link)"
+                                    >
+                                      PAY NOW
+                                    </a>
+                                  </Button>
+                                  <div className="flex items-center gap-2 text-xs text-gray-500">
+                                    <span>via</span>
+                                    <Image src="/quickbooks.svg" alt="QuickBooks" width={120} height={40} className="h-10 w-auto" />
+                                  </div>
+                                </div>
                                 <div className="text-xs text-gray-500">Contact support to obtain a payment link.</div>
                               </>
                             ) : null}

--- a/lib/quickbooks-sync.ts
+++ b/lib/quickbooks-sync.ts
@@ -19,6 +19,7 @@ import {
   findQuickBooksCustomerByDisplayName,
   findQuickBooksInvoiceByDocNumber,
   getQuickBooksInvoice,
+  sendQuickBooksInvoiceEmail,
 } from "@/lib/quickbooks";
 
 function toNumber(value: unknown) {
@@ -217,6 +218,15 @@ export async function syncInvoiceToQuickBooks(
       invoiceTotal: qboState.invoiceTotal,
     });
 
+    // Trigger QuickBooks "Review and Send" email
+    if (client.email) {
+      try {
+        await sendQuickBooksInvoiceEmail(connection.realm_id, qboState.qboInvoiceId, client.email);
+      } catch (emailError) {
+        console.error("Failed to send QuickBooks invoice email:", emailError);
+      }
+    }
+
     await maybeLogMissingPaymentUrl({
       invoice: updatedInvoice,
       paymentUrl: qboState.paymentUrl,
@@ -372,6 +382,15 @@ export async function linkInvoiceByDocNumber(options: {
     is_manual_link: true,
   });
 
+  // Trigger QuickBooks "Review and Send" email
+  if (client.email) {
+    try {
+      await sendQuickBooksInvoiceEmail(connection.realm_id, qboState.qboInvoiceId, client.email);
+    } catch (emailError) {
+      console.error("Failed to send QuickBooks invoice email after link (by DocNumber):", emailError);
+    }
+  }
+
   await maybeLogMissingPaymentUrl({
     invoice,
     paymentUrl: qboState.paymentUrl,
@@ -463,6 +482,15 @@ export async function linkInvoiceById(options: {
     paid_at: qboState.paidAt,
     is_manual_link: true,
   });
+
+  // Trigger QuickBooks "Review and Send" email
+  if (client.email) {
+    try {
+      await sendQuickBooksInvoiceEmail(connection.realm_id, qboState.qboInvoiceId, client.email);
+    } catch (emailError) {
+      console.error("Failed to send QuickBooks invoice email after link (by ID):", emailError);
+    }
+  }
 
   await maybeLogMissingPaymentUrl({
     invoice,

--- a/lib/quickbooks.ts
+++ b/lib/quickbooks.ts
@@ -560,6 +560,15 @@ export async function createQuickBooksInvoice(realmId: string, data: {
   return await getQuickBooksInvoice(realmId, createdInvoiceId);
 }
 
+export async function sendQuickBooksInvoiceEmail(realmId: string, qboInvoiceId: string, emailAddr?: string) {
+  const path = `/v3/company/${realmId}/invoice/${qboInvoiceId}/send${emailAddr ? `?sendTo=${encodeURIComponent(emailAddr)}` : ""}`;
+  return await quickBooksApiRequest({
+    method: "POST",
+    path,
+    contentType: "application/octet-stream",
+  });
+}
+
 export async function getQuickBooksInvoice(realmId: string, qboInvoiceId: string) {
   const result = await quickBooksApiRequest<{ Invoice: Record<string, unknown> }>({
     method: "GET",

--- a/tests/lib/quickbooks-sync.test.ts
+++ b/tests/lib/quickbooks-sync.test.ts
@@ -15,7 +15,11 @@ const {
   findQuickBooksCustomerByDisplayNameMock,
   getQuickBooksInvoiceMock,
   getQuickBooksInvoicePdfMock,
+  sendQuickBooksInvoiceEmailMock,
   extractQuickBooksInvoiceStateMock,
+  findQuickBooksInvoiceByDocNumberMock,
+  createInvoiceMock,
+  checkDuplicateByQboInvoiceIdMock,
 } = vi.hoisted(() => ({
   getQuickBooksConnectionMock: vi.fn(),
   getClientQboInvoiceIdsMock: vi.fn(),
@@ -31,7 +35,11 @@ const {
   findQuickBooksCustomerByDisplayNameMock: vi.fn(),
   getQuickBooksInvoiceMock: vi.fn(),
   getQuickBooksInvoicePdfMock: vi.fn(),
+  sendQuickBooksInvoiceEmailMock: vi.fn(),
   extractQuickBooksInvoiceStateMock: vi.fn(),
+  findQuickBooksInvoiceByDocNumberMock: vi.fn(),
+  createInvoiceMock: vi.fn(),
+  checkDuplicateByQboInvoiceIdMock: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -44,8 +52,8 @@ vi.mock("@/lib/db", () => ({
   getQuickBooksConnection: getQuickBooksConnectionMock,
   updateInvoiceStatusByQuickBooksInvoiceId: updateInvoiceStatusByQuickBooksInvoiceIdMock,
   createMissingPaymentUrlLogIfNeeded: createMissingPaymentUrlLogIfNeededMock,
-  createInvoice: vi.fn(),
-  checkDuplicateByQboInvoiceId: vi.fn(),
+  createInvoice: createInvoiceMock,
+  checkDuplicateByQboInvoiceId: checkDuplicateByQboInvoiceIdMock,
 }));
 
 vi.mock("@/lib/quickbooks", () => ({
@@ -54,11 +62,12 @@ vi.mock("@/lib/quickbooks", () => ({
   createQuickBooksCustomer: createQuickBooksCustomerMock,
   createQuickBooksInvoice: createQuickBooksInvoiceMock,
   findQuickBooksCustomerByDisplayName: findQuickBooksCustomerByDisplayNameMock,
-  findQuickBooksInvoiceByDocNumber: vi.fn(),
+  findQuickBooksInvoiceByDocNumber: findQuickBooksInvoiceByDocNumberMock,
   getQuickBooksInvoicePdf: getQuickBooksInvoicePdfMock,
+  sendQuickBooksInvoiceEmail: sendQuickBooksInvoiceEmailMock,
 }));
 
-import { syncClientInvoicesFromQuickBooks, syncInvoiceByQuickBooksInvoiceId, syncInvoiceToQuickBooks } from "@/lib/quickbooks-sync";
+import { linkInvoiceByDocNumber, syncClientInvoicesFromQuickBooks, syncInvoiceByQuickBooksInvoiceId, syncInvoiceToQuickBooks } from "@/lib/quickbooks-sync";
 
 describe("lib/quickbooks-sync", () => {
   beforeEach(() => {
@@ -155,6 +164,7 @@ describe("lib/quickbooks-sync", () => {
         pdfSize: expect.anything(),
       })
     );
+    expect(sendQuickBooksInvoiceEmailMock).toHaveBeenCalledWith("123", "qbo-inv-1", "billing@acme.com");
   });
 
   it("logs MissingQboPaymentUrl with admin-sync origin when sync results in missing payment URL", async () => {
@@ -234,6 +244,40 @@ describe("lib/quickbooks-sync", () => {
     expect(updateInvoiceStatusByQuickBooksInvoiceIdMock).toHaveBeenCalledWith(expect.objectContaining({
       allowPaymentUrlClear: true,
     }));
+  });
+
+  it("triggers QuickBooks email when manually linking an invoice by DocNumber", async () => {
+    const clientId = "client-1";
+    const qboDocNumber = "INV-100";
+    getQuickBooksConnectionMock.mockResolvedValue({ realm_id: "123" });
+    getClientQuickBooksProfileMock.mockResolvedValue({
+      id: clientId,
+      email: "client@example.com",
+      qbo_customer_id: "qbo-cust-1",
+    });
+    findQuickBooksInvoiceByDocNumberMock.mockResolvedValue({
+      Id: "qbo-inv-100",
+      DocNumber: qboDocNumber,
+      DueDate: "2026-07-01",
+      TxnDate: "2026-06-01",
+      TotalAmt: 200,
+    });
+    extractQuickBooksInvoiceStateMock.mockReturnValue({
+      qboInvoiceId: "qbo-inv-100",
+      qboDocNumber: qboDocNumber,
+      qboSyncStatus: "sent",
+      amountPaid: 0,
+      paidAt: null,
+      paymentUrl: "https://pay.example/100",
+      invoiceDate: "2026-06-01",
+      invoiceTotal: 200,
+    });
+    checkDuplicateByQboInvoiceIdMock.mockResolvedValue(false);
+    createInvoiceMock.mockResolvedValue({ id: "local-inv-100" });
+
+    await linkInvoiceByDocNumber({ clientId, qboDocNumber });
+
+    expect(sendQuickBooksInvoiceEmailMock).toHaveBeenCalledWith("123", "qbo-inv-100", "client@example.com");
   });
 
   it("does not log for qbo-webhook when qbo_payment_url is already null and remains null", async () => {


### PR DESCRIPTION
This PR implements sending invoices by email to clients when they are created or linked by an admin. It also adds "via QuickBooks" logo next to "PAY NOW" button when a qbo_payment_url isn't present instead of just when the url is present.

Closes #40 