### PR TITLE
feat: remove billing address requirement for invoices and portal

### DIFF
--- a/app/api/invoices/route.ts
+++ b/app/api/invoices/route.ts
@@ -260,19 +260,6 @@ export async function POST(req: NextRequest) {
       // { key: "billing_country", label: "country" },
     ];
 
-    const missingBillingFields = requiredBillingFields
-      .filter(({ key }) => !String(selectedClient[key] ?? "").trim())
-      .map(({ label }) => label);
-
-    if (missingBillingFields.length > 0) {
-      return NextResponse.json(
-        {
-          error: `Billing address is incomplete. Missing required fields: ${missingBillingFields.join(", ")}.`,
-        },
-        { status: 400 }
-      );
-    }
-
     const overLimitFields = requiredBillingFields
       .filter(({ key }) => {
         if (key === "billing_state") return false;

--- a/app/portal/page.tsx
+++ b/app/portal/page.tsx
@@ -117,13 +117,6 @@ export default function Portal() {
     loadClient();
   }, [status, userType]);
 
-  const hasBillingAddress = Boolean(
-    client?.billing_address_line1?.trim() &&
-      client?.billing_city?.trim() &&
-      client?.billing_state?.trim() &&
-      client?.billing_postal_code?.trim()
-  );
-
   const firstMissingPaymentUrlInvoice = invoices.find((invoice) => {
     const status = (invoice.qbo_sync_status || "pending").toLowerCase();
     const isUnpaid = status !== "paid";
@@ -240,15 +233,6 @@ export default function Portal() {
               </div>
             )}
           </div>
-          {!hasBillingAddress && (
-            <p className="mb-4 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-lg p-3">
-              Billing address required to receive services. Go to{" "}
-              <a href="/account-settings" className="font-semibold underline">
-                account settings
-              </a>{" "}
-              to add one.
-            </p>
-          )}
           {invoices.length === 0 ? (
             <p className="text-gray-600">No invoices yet.</p>
           ) : (

--- a/tests/app/api/invoices.route.test.ts
+++ b/tests/app/api/invoices.route.test.ts
@@ -193,7 +193,7 @@ describe("/api/invoices reconnect-required responses", () => {
     expect(persistApiErrorMock).toHaveBeenCalled();
   });
 
-  it("blocks invoice creation when required billing address fields are missing", async () => {
+  it("allows invoice creation when required billing address fields are missing", async () => {
     getClientBillingAddressMock.mockResolvedValue({
       id: "1",
       billing_address_line1: null,
@@ -203,12 +203,14 @@ describe("/api/invoices reconnect-required responses", () => {
       billing_country: "US",
     });
 
+    createInvoiceMock.mockResolvedValue({ id: "inv-2", client_id: "1" });
+
     const req = new NextRequest("http://localhost:3000/api/invoices", {
       method: "POST",
       body: JSON.stringify({
         client_id: "1",
         invoice_total: 100,
-        due_date: "2026-07-01",
+        due_date: futureDueDate(),
       }),
       headers: { "content-type": "application/json" },
     });
@@ -216,9 +218,9 @@ describe("/api/invoices reconnect-required responses", () => {
     const res = await POST(req);
     const payload = await res.json();
 
-    expect(res.status).toBe(400);
-    expect(payload.error).toContain("Billing address is incomplete");
-    expect(createInvoiceMock).not.toHaveBeenCalled();
+    expect(res.status).toBe(201);
+    expect(payload.id).toBe("inv-2");
+    expect(createInvoiceMock).toHaveBeenCalled();
   });
 
   it("blocks invoice creation when billing address fields exceed limits", async () => {


### PR DESCRIPTION
closes #49

## Description
This PR removes the logic that mandates a complete billing address before an invoice can be created or displayed in the portal. Clients can now be invoiced and view their portal even with incomplete billing information.

## Changes
- **API**: Removed the `requiredBillingFields` blocking check in `app/api/invoices/route.ts`. Validation for field limits and state code format remains.
- **Portal**: Removed the `hasBillingAddress` check and the warning banner in `app/portal/page.tsx`.
- **Tests**: Updated `tests/app/api/invoices.route.test.ts` to verify that invoices can be created without a billing address.

## Manual QA
1. **Invoice Creation**: Created an invoice for a client with no billing address via the Admin Dashboard. Success.
2. **Portal View**: Logged in as a client with no billing address. The invoice is visible and the "Billing address required" warning banner is gone.
3. **Validation**: Verified that providing a 3-letter state code or an overly long address still triggers a 400 error as intended.