### PR TITLE
Remove SEO claim from Starter Website plan

### DIFF
--- a/components/Pricing.tsx
+++ b/components/Pricing.tsx
@@ -33,7 +33,6 @@ const mainTiers = [
     annual: prices.basicWebsite.annual,
     features: [
       "Professional, mobile-friendly website",
-      "Optimized for Google search (SEO)",
       "Up to 5 pages",
       "Contact form included",
       "Hosting & domain guidance",


### PR DESCRIPTION
## What changed
- Removes “Optimized for Google search (SEO)” from the Starter Website feature list.
- Leaves all other pricing and features unchanged.

## Why
The Starter Website plan should not advertise this SEO claim.

## Validation
- Focused ESLint passed.
- Production build passed.

Closes #55